### PR TITLE
Use member IDs for Slack

### DIFF
--- a/home/src/README.md
+++ b/home/src/README.md
@@ -12,7 +12,7 @@ with your contribution!
 
 For any questions about contributing or about this documentation, please
 contact Bradley Bridges
-(*[@blbridges96](https://uavaustin.slack.com/channels/blbridges96)* on Slack).
+(*[@blbridges96](https://uavaustin.slack.com/messages/U502FRMBM)* on Slack).
 
 ## Contact
 
@@ -20,13 +20,13 @@ For other information, you can contact us via Slack or email:
 
 - Hyeonseung "Shawn" Lee - Program Manager
 
-  *@Shawn Lee* |
+  *[@Shawn Lee*](https://uavaustin.slack.com/messages/U6X0R86FJ) |
   *[hyeonseung.lee@utexas.edu](mailto:hyeonseung.lee@utexas.edu)*
 - Sabrina Alvarez - Chief Engineer
 
-  *[@sab000](https://uavaustin.slack.com/channels/sab000)* |
+  *[@sab000](https://uavaustin.slack.com/messages/U6XKWA20J)* |
   *[alvarez.sabrina84@utexas.edu](mailto:alvarez.sabrina84@utexas.edu)*
 - Bradley Bridges - Chief Software Engineer
 
-  *[@blbridges96](https://uavaustin.slack.com/channels/blbridges96)* |
+  *[@blbridges96](https://uavaustin.slack.com/messages/U502FRMBM)* |
   *[blbridges96@gmail.com](mailto:blbridges96@gmail.com)*


### PR DESCRIPTION
([usernames are dead](https://api.slack.com/changelog/2017-09-the-one-about-usernames), long live member IDs!)

This probably didn't need it's own branch/PR but just in case (it _seems_ to work for me but I might be doing something odd).